### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## 🚀 Summary
+
+<!--
+Provide a clear and concise description of the changes you're making.
+What problem does this solve? What is the motivation behind this change?
+-->
+
+## ✏️ Changes
+
+<!--
+List the specific changes you've made. For example:
+- Added new feature X
+- Fixed bug in Y
+- Updated documentation for Z
+-->
+
+## 🧪 Test Plan
+
+<!--
+For docs-only or non-code changes, delete this entire section (heading included).
+
+Otherwise, describe how you verified the change. For example:
+- Commands run (e.g. `go test ./...`, `pnpm build`)
+- Scenarios exercised manually (golden path + edge cases)
+- New or updated automated tests
+-->


### PR DESCRIPTION
Closes #10

## 🚀 Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md` so GitHub pre-fills every new PR description with consistent sections.

## ✏️ Changes

- Added `.github/PULL_REQUEST_TEMPLATE.md` with Summary, Changes, and Test Plan sections

## 🧪 Test Plan

No code change -- template takes effect automatically when GitHub detects the file. Verified by opening a new draft PR (this one) and confirming the description was pre-filled.