### PR TITLE
feat(`host/router`): add React Router with home and student-insight route

### DIFF
--- a/apps/host/package.json
+++ b/apps/host/package.json
@@ -16,11 +16,11 @@
     "lucide-react": "^1.17.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "react-router": "^7.17.0",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.1",
-    "tw-animate-css": "^1.4.0",
     "@rsbuild/core": "^2.0.12",
     "@rsbuild/plugin-react": "^2.0.1",
     "@rsbuild/plugin-tailwindcss": "^2.0.2",
@@ -28,6 +28,7 @@
     "@types/react-dom": "^19.2.3",
     "shadcn": "^4.11.0",
     "tailwindcss": "^4.3.0",
+    "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3"
   }
 }

--- a/apps/host/src/App.tsx
+++ b/apps/host/src/App.tsx
@@ -1,23 +1,30 @@
+import { BrowserRouter, Route, Routes } from 'react-router';
+
 import { AppSidebar } from '~/components/Sidebar';
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '~/components/ui/sidebar';
 import { TooltipProvider } from '~/components/ui/tooltip';
+import { HomeView } from '~/containers/HomeView';
+import { NotFoundView } from '~/containers/NotFoundView';
+import { StudentsView } from '~/containers/StudentsView';
 
 export default function App() {
   return (
-    <TooltipProvider>
-      <SidebarProvider>
-        <AppSidebar />
-        <SidebarInset>
-          <header className="tw:flex tw:h-14 tw:items-center tw:px-4 tw:md:hidden">
-            <SidebarTrigger />
-          </header>
-        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
-          <h1 className="tw:text-2xl tw:font-semibold tw:text-muted-foreground">
-            Teacher Workspace
-          </h1>
-        </div>
-        </SidebarInset>
-      </SidebarProvider>
-    </TooltipProvider>
+    <BrowserRouter>
+      <TooltipProvider>
+        <SidebarProvider>
+          <AppSidebar />
+          <SidebarInset>
+            <header className="tw:flex tw:h-14 tw:items-center tw:px-4 tw:md:hidden">
+              <SidebarTrigger />
+            </header>
+            <Routes>
+              <Route path="/" element={<HomeView />} />
+              <Route path="/students/*" element={<StudentsView />} />
+              <Route path="*" element={<NotFoundView />} />
+            </Routes>
+          </SidebarInset>
+        </SidebarProvider>
+      </TooltipProvider>
+    </BrowserRouter>
   );
 }

--- a/apps/host/src/App.tsx
+++ b/apps/host/src/App.tsx
@@ -5,6 +5,7 @@ import { SidebarInset, SidebarProvider, SidebarTrigger } from '~/components/ui/s
 import { TooltipProvider } from '~/components/ui/tooltip';
 import { HomeView } from '~/containers/HomeView';
 import { NotFoundView } from '~/containers/NotFoundView';
+import { ParentsGatewayView } from '~/containers/ParentsGatewayView';
 import { StudentsView } from '~/containers/StudentsView';
 
 export default function App() {
@@ -20,6 +21,7 @@ export default function App() {
             <Routes>
               <Route path="/" element={<HomeView />} />
               <Route path="/students/*" element={<StudentsView />} />
+              <Route path="/posts/*" element={<ParentsGatewayView />} />
               <Route path="*" element={<NotFoundView />} />
             </Routes>
           </SidebarInset>

--- a/apps/host/src/components/Sidebar.tsx
+++ b/apps/host/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { CircleHelp, Home, Mail, Settings, Users } from 'lucide-react';
+import { CircleHelp, Home, Mail, Users } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { NavLink } from 'react-router';
 
@@ -20,27 +20,22 @@ import {
 interface NavItem {
   title: string;
   icon: LucideIcon;
-  href: string;
-}
-
-interface MenuItem {
-  title: string;
-  icon: LucideIcon;
+  to: string;
 }
 
 const navItems: NavItem[] = [
-  { title: 'Home', icon: Home, href: '/' },
-  { title: 'Student Insights', icon: Users, href: '/students' },
+  { title: 'Home', icon: Home, to: '/' },
+  { title: 'Student Insights', icon: Users, to: '/students' },
 ];
 
-const communicationsItems: MenuItem[] = [{ title: 'Posts', icon: Mail }];
+const communicationsItems: NavItem[] = [{ title: 'Posts', icon: Mail, to: '/posts' }];
 
 function NavMenuItems({ items }: { items: NavItem[] }) {
   return (
     <SidebarMenu>
       {items.map((item) => (
         <SidebarMenuItem key={item.title}>
-          <NavLink to={item.href} end={item.href === '/'}>
+          <NavLink to={item.to} end={item.to === '/'}>
             {({ isActive }) => (
               <SidebarMenuButton tooltip={item.title} isActive={isActive}>
                 <item.icon className="tw:size-4" />
@@ -48,21 +43,6 @@ function NavMenuItems({ items }: { items: NavItem[] }) {
               </SidebarMenuButton>
             )}
           </NavLink>
-        </SidebarMenuItem>
-      ))}
-    </SidebarMenu>
-  );
-}
-
-function StaticMenuItems({ items }: { items: MenuItem[] }) {
-  return (
-    <SidebarMenu>
-      {items.map((item) => (
-        <SidebarMenuItem key={item.title}>
-          <SidebarMenuButton tooltip={item.title}>
-            <item.icon className="tw:size-4" />
-            <span>{item.title}</span>
-          </SidebarMenuButton>
         </SidebarMenuItem>
       ))}
     </SidebarMenu>
@@ -95,7 +75,7 @@ export function AppSidebar() {
             Communications
           </SidebarGroupLabel>
           <SidebarGroupContent>
-            <StaticMenuItems items={communicationsItems} />
+            <NavMenuItems items={communicationsItems} />
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
@@ -103,16 +83,16 @@ export function AppSidebar() {
       <SidebarFooter>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton tooltip="Settings">
-              <Settings className="tw:size-4" />
-              <span>Settings</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <SidebarMenuButton tooltip="Help">
-              <CircleHelp className="tw:size-4" />
-              <span>Help</span>
-            </SidebarMenuButton>
+            <a
+              href="https://go.gov.sg/teacherworkspace-feedback"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <SidebarMenuButton tooltip="Help">
+                <CircleHelp className="tw:size-4" />
+                <span>Help</span>
+              </SidebarMenuButton>
+            </a>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>

--- a/apps/host/src/components/Sidebar.tsx
+++ b/apps/host/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { CircleHelp, Home, Mail, Settings, Users } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { NavLink } from 'react-router';
 
 import {
   Sidebar as SidebarRoot,
@@ -16,18 +17,44 @@ import {
   SidebarTrigger,
 } from '~/components/ui/sidebar';
 
+interface NavItem {
+  title: string;
+  icon: LucideIcon;
+  href: string;
+}
+
 interface MenuItem {
   title: string;
   icon: LucideIcon;
 }
 
-const mainNavItems: MenuItem[] = [{ title: 'Home', icon: Home }];
-
-const studentInsightItems: MenuItem[] = [{ title: 'Student Insights', icon: Users }];
+const navItems: NavItem[] = [
+  { title: 'Home', icon: Home, href: '/' },
+  { title: 'Student Insights', icon: Users, href: '/students' },
+];
 
 const communicationsItems: MenuItem[] = [{ title: 'Posts', icon: Mail }];
 
-function NavMenuItems({ items }: { items: MenuItem[] }) {
+function NavMenuItems({ items }: { items: NavItem[] }) {
+  return (
+    <SidebarMenu>
+      {items.map((item) => (
+        <SidebarMenuItem key={item.title}>
+          <NavLink to={item.href} end={item.href === '/'}>
+            {({ isActive }) => (
+              <SidebarMenuButton tooltip={item.title} isActive={isActive}>
+                <item.icon className="tw:size-4" />
+                <span>{item.title}</span>
+              </SidebarMenuButton>
+            )}
+          </NavLink>
+        </SidebarMenuItem>
+      ))}
+    </SidebarMenu>
+  );
+}
+
+function StaticMenuItems({ items }: { items: MenuItem[] }) {
   return (
     <SidebarMenu>
       {items.map((item) => (
@@ -60,11 +87,7 @@ export function AppSidebar() {
       <SidebarContent>
         <SidebarGroup className="tw:pb-0">
           <SidebarGroupContent>
-            <NavMenuItems items={mainNavItems} />
-          </SidebarGroupContent>
-
-          <SidebarGroupContent>
-            <NavMenuItems items={studentInsightItems} />
+            <NavMenuItems items={navItems} />
           </SidebarGroupContent>
 
           <SidebarSeparator className="tw:mx-0 tw:mt-3 tw:group-data-[collapsible=icon]:mb-3" />
@@ -72,7 +95,7 @@ export function AppSidebar() {
             Communications
           </SidebarGroupLabel>
           <SidebarGroupContent>
-            <NavMenuItems items={communicationsItems} />
+            <StaticMenuItems items={communicationsItems} />
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>

--- a/apps/host/src/containers/HomeView.tsx
+++ b/apps/host/src/containers/HomeView.tsx
@@ -1,0 +1,7 @@
+export function HomeView() {
+  return (
+    <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
+      <h1 className="tw:text-2xl tw:font-semibold tw:text-muted-foreground">Teacher Workspace</h1>
+    </div>
+  );
+}

--- a/apps/host/src/containers/NotFoundView.tsx
+++ b/apps/host/src/containers/NotFoundView.tsx
@@ -1,0 +1,7 @@
+export function NotFoundView() {
+  return (
+    <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
+      <h1 className="tw:text-2xl tw:font-semibold tw:text-muted-foreground">Page not found</h1>
+    </div>
+  );
+}

--- a/apps/host/src/containers/ParentsGatewayView.tsx
+++ b/apps/host/src/containers/ParentsGatewayView.tsx
@@ -1,0 +1,7 @@
+export function ParentsGatewayView() {
+  return (
+    <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
+      <h1 className="tw:text-2xl tw:font-semibold tw:text-muted-foreground">Parents Gateway</h1>
+    </div>
+  );
+}

--- a/apps/host/src/containers/StudentsView.tsx
+++ b/apps/host/src/containers/StudentsView.tsx
@@ -1,0 +1,7 @@
+export function StudentsView() {
+  return (
+    <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
+      <h1 className="tw:text-2xl tw:font-semibold tw:text-muted-foreground">Student Insight</h1>
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      react-router:
+        specifier: ^7.17.0
+        version: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -1155,6 +1158,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -2094,6 +2101,16 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
@@ -2170,6 +2187,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3546,6 +3566,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -4383,6 +4405,14 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.7
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
   react@19.2.7: {}
 
   recast@0.23.11:
@@ -4479,6 +4509,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
 


### PR DESCRIPTION
Closes #5

## Summary

   - Added React Router v7 (declarative/library mode) to the host shell with `BrowserRouter`, `Routes`, and `Route`
   - Created placeholder views for home (`/`), student insight (`/students/*`), parents gateway (`/posts/*`), and not-found (`*`) routes
   - Wired all sidebar nav items (Home, Student Insights, Posts) with `NavLink` for client-side navigation and active state styling
   - Removed Settings footer item; linked Help to go.gov.sg feedback form

   ## Changes

   - `apps/host/package.json` -- added `react-router@^7` as a runtime dependency
   - `apps/host/src/App.tsx` -- wrapped layout with `BrowserRouter`, added `<Routes>` with home, students, posts, and catch-all routes in the main content region (sidebar remains
   outside Routes)
   - `apps/host/src/components/Sidebar.tsx` -- replaced static menu buttons with `NavLink` using `to` prop and `isActive` styling; removed Settings item; linked Help externally to
   feedback form
   - `apps/host/src/containers/HomeView.tsx` -- new placeholder home page component
   - `apps/host/src/containers/StudentsView.tsx` -- new placeholder student insight page component
   - `apps/host/src/containers/ParentsGatewayView.tsx` -- new placeholder Parents Gateway page component
   - `apps/host/src/containers/NotFoundView.tsx` -- new placeholder not-found page component
   - `pnpm-lock.yaml` -- lockfile update for react-router

   ## Test plan

   - **Student insight page at /students**: `/students` and nested paths render StudentsView
   - **Students sidebar item navigates**: NavLink navigates to `/students` without full reload; active styling applied via `isActive` prop
   - **Parents Gateway at /posts**: `/posts` and nested paths render ParentsGatewayView
   - **Posts sidebar item navigates**: NavLink navigates to `/posts` without full reload; active styling applied
   - **Home page at /**: `/` renders HomeView; Home nav item shows active styling
   - **Home sidebar item navigates**: NavLink navigates to `/` without full reload; active styling applied
   - **Unknown routes**: any unmatched path renders NotFoundView within the shell (sidebar visible)
   - **Help link**: opens go.gov.sg/teacherworkspace-feedback in a new tab
   - **Build verification**: `pnpm build` passes with react-router v7 as a runtime dependency

   ---

 *Generated with aif-implement-issue*
  