### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: ['*']
+
+permissions:
+  contents: read
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Format
+        run: pnpm format
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint --format=github
+
+  go-lint:
+    name: Go Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        with:
+          version: v2.12.2
+
+  go-test:
+    name: Go Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Run tests
+        run: go test -race ./...


### PR DESCRIPTION
## 🚀 Summary

Adds `.github/workflows/ci.yml` to run automated checks on every pull request. Implements #11.

Four jobs run in parallel on each PR: **Format**, **Lint**, **Go Lint**, and **Go Test**. In-progress runs are cancelled when a newer commit is pushed to the same ref.

## ✏️ Changes

- Added `.github/workflows/ci.yml` with four parallel jobs
- All actions pinned to full 40-character commit SHAs with `# vX.Y.Z` version comments
- Action versions refreshed from archive baselines to latest stable:

  | Action | Archive baseline | Pinned |
  |---|---|---|
  | `actions/checkout` | v6 | v7.0.0 |
  | `pnpm/action-setup` | v4 | v6.0.9 |
  | `actions/setup-node` | v6 | v6.4.0 |
  | `actions/setup-go` | v6 | v6.5.0 |
  | `golangci/golangci-lint-action` | v9 | v9.2.1 |

- golangci-lint binary pinned to `v2.12.2`
- Go version resolved from `go.mod` via `go-version-file` (currently `go 1.26`)
- `permissions: contents: read` only

## 🧪 Test Plan

- All action SHAs resolved via GitHub API; annotated tags (`pnpm/action-setup`, `golangci-lint-action`) dereferenced to their underlying commit SHAs
- Versions confirmed as latest stable via `/releases` endpoint filtered for `prerelease == false && draft == false`
- All five hard constraints from #11 verified: SHA pinning, `v2.12.2` golangci-lint, `pull_request`-only trigger, `contents: read` permissions, lint scripts untouched