### PR TITLE
fix(`host/sidebar`): add gap-1 between menu items and cursor-pointer on buttons

### DIFF
--- a/apps/host/src/components/ui/sidebar.tsx
+++ b/apps/host/src/components/ui/sidebar.tsx
@@ -253,7 +253,7 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon-sm"
-      className={cn(className)}
+      className={cn('tw:cursor-pointer', className)}
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();
@@ -437,7 +437,7 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
     <ul
       data-slot="sidebar-menu"
       data-sidebar="menu"
-      className={cn('tw:flex tw:w-full tw:min-w-0 tw:flex-col tw:gap-0', className)}
+      className={cn('tw:flex tw:w-full tw:min-w-0 tw:flex-col tw:gap-1', className)}
       {...props}
     />
   );
@@ -458,7 +458,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  'tw:peer/menu-button tw:group/menu-button tw:flex tw:w-full tw:items-center tw:gap-2 tw:overflow-hidden tw:rounded-md tw:p-2 tw:text-left tw:text-sm tw:ring-sidebar-ring tw:outline-hidden tw:transition-[width,height,padding] tw:group-has-data-[sidebar=menu-action]/menu-item:pr-8 tw:group-data-[collapsible=icon]:size-8! tw:group-data-[collapsible=icon]:p-2! tw:hover:bg-sidebar-accent tw:hover:text-sidebar-accent-foreground tw:focus-visible:ring-2 tw:active:bg-sidebar-accent tw:active:text-sidebar-accent-foreground tw:disabled:pointer-events-none tw:disabled:opacity-50 tw:aria-disabled:pointer-events-none tw:aria-disabled:opacity-50 tw:data-open:hover:bg-sidebar-accent tw:data-open:hover:text-sidebar-accent-foreground tw:data-active:bg-sidebar-accent tw:data-active:font-medium tw:data-active:text-sidebar-accent-foreground tw:[&_svg]:size-4 tw:[&_svg]:shrink-0 tw:[&>span:last-child]:truncate',
+  'tw:peer/menu-button tw:group/menu-button tw:flex tw:w-full tw:cursor-pointer tw:items-center tw:gap-2 tw:overflow-hidden tw:rounded-md tw:p-2 tw:text-left tw:text-sm tw:ring-sidebar-ring tw:outline-hidden tw:transition-[width,height,padding] tw:group-has-data-[sidebar=menu-action]/menu-item:pr-8 tw:group-data-[collapsible=icon]:size-8! tw:group-data-[collapsible=icon]:p-2! tw:hover:bg-sidebar-accent tw:hover:text-sidebar-accent-foreground tw:focus-visible:ring-2 tw:active:bg-sidebar-accent tw:active:text-sidebar-accent-foreground tw:disabled:pointer-events-none tw:disabled:opacity-50 tw:aria-disabled:pointer-events-none tw:aria-disabled:opacity-50 tw:data-open:hover:bg-sidebar-accent tw:data-open:hover:text-sidebar-accent-foreground tw:data-active:bg-sidebar-accent tw:data-active:font-medium tw:data-active:text-sidebar-accent-foreground tw:[&_svg]:size-4 tw:[&_svg]:shrink-0 tw:[&>span:last-child]:truncate',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

- `SidebarMenu`: `gap-0` → `gap-1` — adds a small gap between nav items in the sidebar
- `SidebarMenuButton`: adds `tw:cursor-pointer` — ensures the pointer cursor shows on hover over nav items
- `SidebarTrigger`: adds `tw:cursor-pointer` — ensures the pointer cursor shows on hover over the collapse/expand button

## Test plan

- [x] Open the sidebar and confirm nav items have a small gap between them
- [x] Hover over a sidebar nav item and confirm the cursor changes to a pointer
- [x] Hover over the collapse/expand toggle button and confirm the cursor changes to a pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)