### PR TITLE
fix(host): remove dead source.alias config from rsbuild.config.ts

### DIFF
--- a/apps/host/rsbuild.config.ts
+++ b/apps/host/rsbuild.config.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
@@ -28,10 +26,5 @@ export default defineConfig({
   ],
   html: {
     template: './index.html',
-  },
-  source: {
-    alias: {
-      '~': path.resolve(import.meta.dirname, 'src'),
-    },
   },
 });


### PR DESCRIPTION
## Summary
- `@rsbuild/core` v2 moved path aliasing from `source.alias` to `resolve.alias`. The leftover v1-style `source.alias` block in `apps/host/rsbuild.config.ts` was a TypeScript type error (`Object literal may only specify known properties, and 'alias' does not exist in type 'SourceConfig'`) and had zero effect on the actual build.
- `~` imports keep resolving correctly via `tsconfig.json`'s `paths` field, which rsbuild already honors through its default `aliasStrategy: 'prefer-tsconfig'`.
- Verified by diffing `apps/host/dist` built with and without the block — output was byte-for-byte identical, confirming the block was dead code.

## Test plan
- [x] `npx tsc --noEmit -p apps/host/tsconfig.json` passes with zero errors (previously failed with `TS2769`)
- [x] `pnpm --filter @teacher-workspace/host build` succeeds
- [x] `oxlint` / `oxfmt` clean on the changed file
- [x] Confirmed `~/...` imports (e.g. `Sidebar.tsx`) still resolve — built output content is identical to the version with `source.alias` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)