### PR TITLE
fix(ci): pin pnpm to an exact version instead of a floating major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          version: 11.7.0
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          version: 11.7.0
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.7.0
+          version: 11.11.0
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.7.0
+          version: 11.11.0
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## Why this fix exists

`.github/workflows/ci.yml` had `pnpm/action-setup` configured with `version: 11` — a floating major-version spec, not a fixed version. In practice, that means every CI run asks "give me whatever the newest 11.x release is right now," rather than a version anyone chose deliberately.

pnpm published `11.12.0`, and it has a real bug in its self-update logic — confirmed upstream in [pnpm/pnpm#12959](https://github.com/pnpm/pnpm/issues/12959): a lockfile-merging bug causes `pnpm self-update` to crash with `Cannot use 'in' operator to search for 'integrity' in undefined` when installing itself. Because our CI was floating on `version: 11`, it picked up this broken release automatically and started failing — with no change to our own code. (Corroborated independently at [pnpm/action-setup#276](https://github.com/pnpm/action-setup/issues/276), with the exact same stack trace we hit.)

The fix: pin to an exact version instead of floating, so a bad upstream release can no longer silently break our CI — we control exactly when we move to a new version. This also brings the `pnpm` version pin in line with every other tool in this workflow, which is already pinned exactly (`actions/checkout`, `actions/setup-node`, `golangci-lint-action`, and even `pnpm/action-setup`'s own commit SHA).

### Why `11.11.0` specifically

- `11.7.0` was the last version already cached and known-working on our runners before this incident — the safest, zero-research choice.
- Checked `11.8.0` → `11.11.0`'s changelogs: no breaking changes for a plain `pnpm install --frozen-lockfile` + lint/format/build workflow, and `11.11.0` brings real improvements over `11.7.0` — two path-traversal security fixes in the virtual-store linker, and a fix for a non-deterministic peer-resolution race that caused lockfile churn / flaky `dedupe --check` failures.
- `11.11.0` does have one reported regression, [pnpm/pnpm#12921](https://github.com/pnpm/pnpm/issues/12921) (a peer-resolution deadlock with `electron-builder`) — doesn't apply here, since this repo has no Electron dependency anywhere.
- Deliberately **not** jumping to `11.13.0` (the newest release, published the day after the bug report) — it's a day old with no track record, which is exactly the failure mode that got us into this in the first place. Its changelog also doesn't confirm fixing our specific bug (#12959); it closes a different, adjacent bug from the same broken `11.12.0` release ([#12955](https://github.com/pnpm/pnpm/issues/12955), a tarball-install issue).

**Trade-off**: this version won't auto-update anymore, so bumping it later to pick up newer pnpm releases will need to be a deliberate, manual change — same maintenance model as every other pin in this workflow.

## Test plan

- [x] Confirmed the exact failure this fixes on PR #46 (`Format`/`Lint` jobs failing with the `integrity` crash while `Go Lint`/`Go Test` pass, since those don't touch pnpm)
- [x] This PR's own CI run passed `Format` and `Lint` with `11.7.0`; re-confirming after bumping to `11.11.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)