### PR TITLE
chore: type lefthook.yml with a JSON Schema and validate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,26 @@ jobs:
       - name: Lint
         run: pnpm lint --format=github
 
+  validate-config:
+    name: Validate Config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.11.0
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Validate lefthook config
+        run: pnpm lefthook validate
+
   go-lint:
     name: Go Lint
     runs-on: ubuntu-latest

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["oxc.oxc-vscode", "golang.go"]
+  "recommendations": ["oxc.oxc-vscode", "golang.go", "redhat.vscode-yaml"]
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,13 +1,15 @@
+# yaml-language-server: $schema=node_modules/lefthook/schema.json
 pre-commit:
   piped: true
-  exclude: "pnpm-lock.yaml"
+  exclude:
+    - 'pnpm-lock.yaml'
   jobs:
     - name: format
       run: pnpm oxfmt --write {staged_files}
-      glob: "*.{js,jsx,ts,tsx,md,html,css,json,jsonc,yaml,toml}"
+      glob: '*.{js,jsx,ts,tsx,md,html,css,json,jsonc,yaml,toml}'
       stage_fixed: true
 
     - name: lint
       run: pnpm oxlint --fix {staged_files}
-      glob: "*.{js,jsx,ts,tsx}"
+      glob: '*.{js,jsx,ts,tsx}'
       stage_fixed: true


### PR DESCRIPTION
## Why

`lefthook.yml` on `main` contains an invalid value:

```yaml
pre-commit:
  exclude: "pnpm-lock.yaml"   # rejected — must be an array
```

Hook-level `exclude` accepts **only an array**, while job- and command-level `exclude` also accept a bare string. Verified against lefthook `v2.1.9`:

| Source | Hook | Job / Command |
|---|---|---|
| [`internal/config/hook.go:14`](https://github.com/evilmartians/lefthook/blob/v2.1.9/internal/config/hook.go#L14) vs [`job.go:17`](https://github.com/evilmartians/lefthook/blob/v2.1.9/internal/config/job.go#L17) | `Exclude []string`, no jsonschema tag | `jsonschema:"oneof_type=string;array"` |
| `schema.json` | `{"type":"array"}` | `{"oneOf":[string, array]}` |

`pnpm lefthook validate` on `main` fails:

```
pre-commit:
  exclude: Value is string but should be array
Error: validation failed for main config   # exit 1
```

Nothing in the repo caught this, so it sat in `main` unnoticed.

## What changed

- **`lefthook.yml`** — `exclude` converted to an array, plus a `# yaml-language-server: $schema=` modeline.
- **`.vscode/extensions.json`** — recommend `redhat.vscode-yaml`. Without a YAML language server nothing applies the schema; the repo only recommended oxc and Go.
- **`.github/workflows/ci.yml`** — new `Validate Config` job running `pnpm lefthook validate`.

### Why a modeline over `yaml.schemas` in `.vscode/settings.json`

- **Editor-agnostic** — VS Code, [Zed](https://zed.dev/docs/languages/yaml), Neovim and Helix all run the same [yaml-language-server](https://github.com/redhat-developer/yaml-language-server#using-inlined-schema), and JetBrains reads the `# $schema:` variant. A `.vscode/` setting only helps VS Code users.
- **Version-pinned** — the relative path resolves from the YAML file's location to `node_modules`, so it validates against the installed 2.1.9 rather than SchemaStore's `master` URL, which can drift from the binary.
- **Reviewable** — the association lives next to the config it governs.

SchemaStore still covers `ci.yml`, `pnpm-workspace.yaml` and `.golangci.yaml` automatically; no config needed for those.

## Verification

- `lefthook validate` → `All good` (was exit 1 on `main`)
- `check-jsonschema --schemafile node_modules/lefthook/schema.json lefthook.yml` → `ok`
- `check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/ci.yml` → `ok`
- Regression simulated: reverting `exclude` to the string form makes the new CI job exit 1, then passes again once restored.
- `oxfmt --check` clean on all three files; pre-commit hook ran and passed on commit.

## Notes

- Quote-style churn in `lefthook.yml` is oxfmt normalising `"` → `'`. That file was **already** failing `oxfmt --check` on `main` — see below.
- The new CI job uses only static commands, no `github.event` interpolation.

## Follow-up (not in this PR)

The format glob is `*.{js,jsx,ts,tsx,md,html,css,json,jsonc,yaml,toml}` — it lists `yaml` but **not `yml`**. So `lefthook.yml` and `.github/workflows/ci.yml` are never formatted by the hook or by `pnpm format`, which is why `lefthook.yml` had drifted out of format on `main`. Adding `yml` would fix it but reformats unrelated files, so I left it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)