### PR TITLE
chore(deps): pin Go to 1.26.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All future front-end apps live under `apps/` and are scoped `@teacher-workspace/
 | ---- | ------- |
 | Node | 24      |
 | pnpm | 11      |
-| Go   | 1.26    |
+| Go   | 1.26.5  |
 
 Node and pnpm versions are enforced via the `engines` field in the root `package.json`. No `.nvmrc` is used; use a version manager that respects `engines` (e.g. [Volta](https://volta.sh/), `fnm`).
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/String-sg/teacher-workspace
 
-go 1.26
-
-toolchain go1.26.0
+go 1.26.5
 
 require github.com/go-viper/mapstructure/v2 v2.5.0


### PR DESCRIPTION
## 🚀 Summary

The `go` directive was set to `1.26`, which is a *floor*, not a pin: any newer 1.26.x toolchain on a contributor machine or CI runner satisfies it, so builds were not guaranteed to be on the same Go version. This pins the module to the exact current patch release, 1.26.5.

It also removes the `toolchain go1.26.0` directive. That line looked redundant next to `go 1.26`, but it was not harmless: [`actions/setup-go` reads a `toolchain` directive in preference to the `go` directive](https://github.com/actions/setup-go/blob/v6/src/installer.ts), so leaving it in place would have made CI install **1.26.0** and silently ignore the pin.

No CI change is needed. Both Go jobs already use `go-version-file: 'go.mod'`, and setup-go matches `^go (\d+(\.\d+)*)`, capturing the full patch. CI therefore resolves to exactly 1.26.5, and `go.mod` stays the single source of truth for the Go version.

Note that `go 1.26.5` still only raises the floor. Anyone on a *newer* Go will keep using it. Truly freezing the toolchain in both directions needs `GOTOOLCHAIN=go1.26.5` in the environment. CI is exact regardless, because setup-go exports `GOTOOLCHAIN=local` so no auto-download can substitute another version.

## ✏️ Changes

- `go.mod`: `go 1.26` → `go 1.26.5`, and removed the `toolchain go1.26.0` directive
- `README.md`: toolchain table now reads Go 1.26.5

## 🧪 Test Plan

Verified locally that the pin is actually enforced. The machine has go1.26.2 installed, older than the pin:

- `GOTOOLCHAIN=local go build ./...` → correctly rejected: `go.mod requires go >= 1.26.5 (running go 1.26.2; GOTOOLCHAIN=local)`
- `go build ./...` (default `GOTOOLCHAIN=auto`) → downloaded go1.26.5 and built successfully

Then ran the CI-equivalent checks under go1.26.5:

- `go test -race ./...` → all packages pass
- `go vet ./...` → clean
- `gofmt -l .` → no output