### PR TITLE
fix(`host/sidebar`): close the mobile sidebar after selecting an app

### DIFF
--- a/apps/host/src/components/Sidebar.tsx
+++ b/apps/host/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   SidebarMenuItem,
   SidebarSeparator,
   SidebarTrigger,
+  useSidebar,
 } from '~/components/ui/sidebar';
 
 interface NavItem {
@@ -34,11 +35,13 @@ const communicationsItems: NavItem[] = [
 ];
 
 function NavMenuItems({ items }: { items: NavItem[] }) {
+  const { setOpenMobile } = useSidebar();
+
   return (
     <SidebarMenu>
       {items.map((item) => (
         <SidebarMenuItem key={item.title}>
-          <NavLink to={item.to} end={item.to === '/'}>
+          <NavLink to={item.to} end={item.to === '/'} onClick={() => setOpenMobile(false)}>
             {({ isActive }) => (
               <SidebarMenuButton tooltip={item.title} isActive={isActive}>
                 <item.icon className="tw:size-4" />


### PR DESCRIPTION
## 🚀 Summary

On mobile (viewport under 768px) the sidebar renders as a sheet overlaying the page. Selecting an app changed the route but left the sheet open, covering the app that was just opened.

`openMobile` had only two writers: `toggleSidebar` (the hamburger and the in-sheet trigger) and the sheet's own dismiss handlers (backdrop tap, Escape). Client-side navigation is neither, so nothing reset it. A full page reload did close it, since `openMobile` initialises to `false`, which is likely why this went unnoticed.

## ✏️ Changes

- `NavMenuItems` in `apps/host/src/components/Sidebar.tsx` now reads `setOpenMobile` from `useSidebar` and closes the mobile sidebar when a nav item is selected.

The fix sits in `components/Sidebar.tsx` rather than `components/ui/sidebar.tsx`, so the shadcn primitive stays regenerable. No `isMobile` guard is needed: `openMobile` is only read inside the `isMobile` branch of `Sidebar`, and on desktop it is already `false`, so the write is inert.

## 🧪 Test Plan

manually tested; https://drive.google.com/file/d/1r4YZjb-PxI0F5K5yqXfZQyol37OWyagx/view?usp=sharing

j/k;


Checks:

- `pnpm lint` passes
- `oxfmt --check` passes on the changed file
- `tsc --noEmit -p apps/host` passes

Manual, viewport at 390px:

- Opened the sidebar and selected `Student Insights`: sidebar closes and the route renders
- Opened the sidebar and selected `Groups`: sidebar closes and the route renders
- Before this change, the sheet and its backdrop stayed open indefinitely after selecting an app

Manual, viewport at 1200px:

- Desktop sidebar is unaffected: navigation works and the sidebar stays expanded

Not covered: close latency on the remote-backed routes (`/posts`, `/groups`) over a slow connection. The route chunk load and the sheet close overlap, and the timing could not be measured reliably. Worth a look on a throttled connection during review.
