### PR TITLE
chore: use array form for hook-level exclude

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,7 @@
 pre-commit:
   piped: true
-  exclude: "pnpm-lock.yaml"
+  exclude:
+    - "pnpm-lock.yaml"
   jobs:
     - name: format
       run: pnpm oxfmt --write {staged_files}


### PR DESCRIPTION
## 🚀 Summary

`pre-commit.exclude` in `lefthook.yml` is a bare string. Hook-level `exclude` is declared `[]string` in lefthook v2.1.9, so `pnpm lefthook validate` fails on `main`:

```
pre-commit:
  exclude: Value is string but should be array
Error: validation failed for main config   # exit 1
```

Only job- and command-level `exclude` also accept a bare string. Nothing in the repo runs `lefthook validate`, so this sat in `main` unnoticed.

Previously part of #56 (closed). This lands only the config correction, without that PR's schema modeline or CI validation job.

## ✏️ Changes

- `lefthook.yml` — `pre-commit.exclude` converted from a string to a single-item array.

## 🧪 Test Plan

- `pnpm lefthook validate` → `All good` (exit 1 on `main`).
- Filtering behaviour unchanged. In a scratch repo on lefthook v2.1.9 with `pnpm-lock.yaml`, `a.ts` and `other.yaml` staged, the job receives `a.ts other.yaml` under both the string and array forms, including for a nested `nested/pnpm-lock.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)