### PR TITLE
chore(`Dockerfile`): add multi-stage image build and CI build job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+.DS_Store
+
+# Ignore docker files.
+.dockerignore
+**/Dockerfile
+
+# Ignore git directory and files.
+.git
+.github
+.gitignore
+
+# Ignore editor directories and files.
+.idea
+.vscode
+
+# Ignore worktrees and documentation.
+.worktrees
+docs
+
+# Ignore node modules.
+node_modules
+**/node_modules
+
+# Ignore cache/output directories. These use **/ so they match at any depth,
+# matching how .gitignore treats them.
+**/bin
+**/build
+**/out
+**/tmp
+**/dist
+**/@mf-types
+
+# Ignore environment variables.
+**/*.env*

--- a/.dockerignore
+++ b/.dockerignore
@@ -13,10 +13,6 @@
 .idea
 .vscode
 
-# Ignore worktrees and documentation.
-.worktrees
-docs
-
 # Ignore node modules.
 node_modules
 **/node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,19 @@ jobs:
           go-version-file: 'go.mod'
       - name: Run tests
         run: go test -race ./...
+
+  build-image:
+    name: Build image
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Build image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,23 +54,6 @@ pnpm build
 TW_ENV=production go run ./server/cmd/tw
 ```
 
-### Container image
-
-The repository-root `Dockerfile` builds the frontend and the server into a single image, so running Teacher Workspace needs only a container runtime instead of the Go, Node, and pnpm toolchains. A local build targets your own machine's architecture; CI builds `linux/arm64`:
-
-```bash
-docker build -t teacher-workspace .
-docker run --rm -p 3000:3000 teacher-workspace
-```
-
-Open <http://localhost:3000>. The image ships no `.env`, so every setting comes from `TW_*` variables and can be overridden at run time:
-
-```bash
-docker run --rm -p 8080:8080 -e TW_SERVER_PORT=8080 teacher-workspace
-```
-
-CI builds the image on every pull request. It is not pushed to any registry.
-
 ### Common commands
 
 Server:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,23 @@ pnpm build
 TW_ENV=production go run ./server/cmd/tw
 ```
 
+### Container image
+
+The repository-root `Dockerfile` builds the frontend and the server into a single image, so running Teacher Workspace needs only a container runtime instead of the Go, Node, and pnpm toolchains. A local build targets your own machine's architecture; CI builds `linux/arm64`:
+
+```bash
+docker build -t teacher-workspace .
+docker run --rm -p 3000:3000 teacher-workspace
+```
+
+Open <http://localhost:3000>. The image ships no `.env`, so every setting comes from `TW_*` variables and can be overridden at run time:
+
+```bash
+docker run --rm -p 8080:8080 -e TW_SERVER_PORT=8080 teacher-workspace
+```
+
+CI builds the image on every pull request. It is not pushed to any registry.
+
 ### Common commands
 
 Server:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,88 @@
+# syntax=docker/dockerfile:1
+
+# ----------------------------------------
+# Host build stage
+# ----------------------------------------
+FROM node:24-alpine3.23 AS host-build
+
+# Keep in sync with the pnpm/action-setup version in .github/workflows/ci.yml,
+# so the image and CI resolve dependencies identically.
+ARG PNPM_VERSION=11.11.0
+
+WORKDIR /src
+
+RUN npm install --global pnpm@${PNPM_VERSION}
+
+# Fetch all dependencies for better layer caching. Every workspace package
+# matched by pnpm-workspace.yaml needs its manifest copied here, otherwise the
+# frozen lockfile install fails on the missing importer.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/host/package.json apps/host/
+
+# --ignore-scripts skips the root prepare script, which installs the lefthook
+# git hooks and fails without a .git directory.
+RUN pnpm install --frozen-lockfile --ignore-scripts
+
+# Only apps/, so an edit under server/ leaves this stage cached.
+COPY apps/ apps/
+
+# Build the frontend into apps/host/dist.
+RUN pnpm build
+
+# ----------------------------------------
+# Server build stage
+# ----------------------------------------
+FROM golang:1.26.5-alpine3.23 AS server-build
+
+# BuildKit populates TARGETARCH from the platform being built. Hardcoding it
+# would emit a binary for the wrong architecture whenever the build host is not
+# arm64, which fails at run time rather than at build time.
+ARG TARGETARCH
+
+WORKDIR /src
+
+# Fetch all dependencies for better layer caching.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY server/ server/
+
+# Build the binary. CGO_ENABLED=0 keeps it static so it does not depend on the
+# runtime stage's libc.
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o /src/tw ./server/cmd/tw
+
+# ----------------------------------------
+# Production stage
+# ----------------------------------------
+FROM alpine:3.23
+
+WORKDIR /app
+
+# No apk install step: alpine already ships ca-certificates-bundle, which is the
+# trusted root store a static Go binary reads, and adduser/addgroup are busybox
+# builtins. Keeping the stage offline makes the build reproducible.
+
+# 1. Create a new user named `tw`.
+# 2. Change the permission of `app` folder to user `tw`.
+# 3. Change the current user from `root` to `tw`.
+RUN addgroup -S tw && \
+        adduser -S tw -G tw && \
+        chown tw:tw /app
+
+USER tw
+
+COPY --from=server-build --chown=tw:tw /src/tw /app/tw
+COPY --from=host-build --chown=tw:tw /src/apps/host/dist /app/dist
+
+# The image ships no .env, so every setting comes from the environment.
+# TW_BUILD_DIR is absolute because config.Validate resolves it against the
+# working directory.
+ENV TW_ENV=production \
+    TW_BUILD_DIR=/app/dist \
+    TW_SERVER_PORT=3000
+
+EXPOSE 3000
+
+# Exec form, so the server is PID 1 and receives SIGTERM for graceful shutdown.
+CMD ["/app/tw"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,11 +46,8 @@ RUN go mod download
 COPY server/ server/
 
 # Build the binary. CGO_ENABLED=0 keeps it static so it does not depend on the
-# runtime stage's libc. No GOOS/GOARCH needed: the golang base image for this
-# stage is already Linux and already matches --platform, so go build defaults
-# to the right OS and architecture.
-RUN CGO_ENABLED=0 \
-    go build -trimpath -ldflags="-s -w" -o /src/tw ./server/cmd/tw
+# runtime stage's libc.
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /src/tw ./server/cmd/tw
 
 # ----------------------------------------
 # Production stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,18 +13,21 @@ WORKDIR /src
 
 RUN npm install --global pnpm@${PNPM_VERSION}
 
-# Fetch all dependencies for better layer caching. Every workspace package
-# matched by pnpm-workspace.yaml needs its manifest copied here, otherwise the
-# frozen lockfile install fails on the missing importer.
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY apps/host/package.json apps/host/
+# Fetch all dependencies into the local store for better layer caching. This
+# reads only pnpm-lock.yaml, so it doesn't need every workspace package's
+# manifest copied in ahead of time.
+COPY pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm fetch
 
+# Only package.json and apps/, so an edit under server/ leaves this stage
+# cached.
+COPY package.json ./
+COPY apps/ apps/
+
+# --offline links from the store fetched above instead of hitting the network.
 # --ignore-scripts skips the root prepare script, which installs the lefthook
 # git hooks and fails without a .git directory.
-RUN pnpm install --frozen-lockfile --ignore-scripts
-
-# Only apps/, so an edit under server/ leaves this stage cached.
-COPY apps/ apps/
+RUN pnpm install --offline --frozen-lockfile --ignore-scripts
 
 # Build the frontend into apps/host/dist.
 RUN pnpm build
@@ -33,11 +36,6 @@ RUN pnpm build
 # Server build stage
 # ----------------------------------------
 FROM golang:1.26.5-alpine3.23 AS server-build
-
-# BuildKit populates TARGETARCH from the platform being built. Hardcoding it
-# would emit a binary for the wrong architecture whenever the build host is not
-# arm64, which fails at run time rather than at build time.
-ARG TARGETARCH
 
 WORKDIR /src
 
@@ -48,8 +46,10 @@ RUN go mod download
 COPY server/ server/
 
 # Build the binary. CGO_ENABLED=0 keeps it static so it does not depend on the
-# runtime stage's libc.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+# runtime stage's libc. No GOOS/GOARCH needed: the golang base image for this
+# stage is already Linux and already matches --platform, so go build defaults
+# to the right OS and architecture.
+RUN CGO_ENABLED=0 \
     go build -trimpath -ldflags="-s -w" -o /src/tw ./server/cmd/tw
 
 # ----------------------------------------
@@ -59,30 +59,22 @@ FROM alpine:3.23
 
 WORKDIR /app
 
-# No apk install step: alpine already ships ca-certificates-bundle, which is the
-# trusted root store a static Go binary reads, and adduser/addgroup are busybox
-# builtins. Keeping the stage offline makes the build reproducible.
+# 1. Create a new user named `zero`.
+# 2. Change the permission of `app` folder to user `zero`.
+# 3. Change the current user from `root` to `zero`.
+RUN addgroup -S zero && \
+        adduser -S zero -G zero && \
+        chown zero:zero /app
 
-# 1. Create a new user named `tw`.
-# 2. Change the permission of `app` folder to user `tw`.
-# 3. Change the current user from `root` to `tw`.
-RUN addgroup -S tw && \
-        adduser -S tw -G tw && \
-        chown tw:tw /app
+USER zero
 
-USER tw
+COPY --from=server-build --chown=zero:zero /src/tw /app/tw
+COPY --from=host-build --chown=zero:zero /src/apps/host/dist /app/dist
 
-COPY --from=server-build --chown=tw:tw /src/tw /app/tw
-COPY --from=host-build --chown=tw:tw /src/apps/host/dist /app/dist
-
-# The image ships no .env, so every setting comes from the environment.
-# TW_BUILD_DIR is absolute because config.Validate resolves it against the
-# working directory.
 ENV TW_ENV=production \
     TW_BUILD_DIR=/app/dist \
     TW_SERVER_PORT=3000
 
 EXPOSE 3000
 
-# Exec form, so the server is PID 1 and receives SIGTERM for graceful shutdown.
 CMD ["/app/tw"]


### PR DESCRIPTION
## 🚀 Summary

The only documented way to run Teacher Workspace in production mode is `pnpm build` followed by `TW_ENV=production go run ./server/cmd/tw`, which needs Go, Node, and pnpm installed on the host and produces no artifact to hand to a deployment target. This adds a multi-stage `Dockerfile` that packages the Go server and the `apps/host` bundle into a single container image, plus a CI job that builds it on every pull request, so Teacher Workspace can run anywhere a container runs.

This first pass is deliberately limited to **arm64 Alpine only** (the repo is public, so `ubuntu-24.04-arm` runners build it natively with no QEMU) and **no push** (`push: false`, so no registry credentials or tagging scheme are introduced yet).

Closes #65.

## ✏️ Changes

- Added a repository-root `Dockerfile` with three stages: `host-build` (Rsbuild build of `apps/host`), `server-build` (static Go build of `server/cmd/tw`), and a minimal Alpine runtime stage running as a non-root user (`zero`).
- Added `.dockerignore` to keep `node_modules`, `dist`, `.git`, `.env`, and editor directories out of the build context.
- Added a `build-image` job to `.github/workflows/ci.yml`, running alongside the existing Format, Lint, Go Lint, and Go Test jobs with no `needs:` gate.

### Updates from review

- Dropped `TARGETARCH`/`GOARCH`/`GOOS` from the Go build: the base image for that stage already matches the target platform and is always Linux, so `go build` defaults to both correctly without being told.
- Switched dependency fetching to `pnpm fetch`, which only reads `pnpm-lock.yaml`, so adding a new app under `apps/*` later needs no Dockerfile change to copy its manifest in.
- Renamed the container user from `tw` to `zero`, a more generic name.
- Removed unused `.worktrees`/`docs` entries from `.dockerignore` (this repo has neither).
- Held off documenting the container image build in `CONTRIBUTING.md` until the deployment flow is settled.
- Trimmed a few comments that just restated context covered elsewhere, including the one justifying the now-removed `GOOS`/`GOARCH`; collapsed the Go build `RUN` back onto a single line now that it's short enough.
- Considered switching to the `ghcr.io/pnpm/pnpm` base image and a `pnpm`-standalone-binary install instead of `npm install --global pnpm`; kept `npm install` for both: the standalone binary segfaults on arm64 Alpine for every pnpm 11.x release (which this repo's `engines.pnpm: ^11.0.0` requires), and the base-image swap wasn't adopted for this pass.

## 🧪 Test Plan

Built and ran the image locally end to end (Docker daemon started explicitly for this since it wasn't running by default):

- `docker build -t teacher-workspace:test .` succeeds; image is `linux/arm64`, ~7.5 MB
- `GET /` → `200` with `index.html`; a real hashed asset under `/static/` → `200`; `GET /anything` (unknown client route) → `200`, byte-identical to `/`; missing asset under `/static/` → `404`
- Server starts from environment variables alone (no `.env` in the image); `-e TW_SERVER_PORT=8080` is honored and the startup log reflects it
- Runtime image contains no build toolchain: `go`, `node`, `pnpm` all absent; `/app` holds only `tw` and `dist`; no `/src`; no `.env` or `node_modules` anywhere in the filesystem
- Runs as non-root (`uid=100(zero) gid=101(zero)`)
- `docker stop` exits cleanly with code `0` in ~216ms (graceful `SIGTERM` shutdown via exec-form `CMD`)
- Verified version pins are in sync: `golang:1.26.5-alpine3.23` matches `go.mod`'s `go 1.26.5`, and `PNPM_VERSION=11.11.0` matches `pnpm/action-setup`'s `version: 11.11.0` in `ci.yml`
- Verified the two new/changed GitHub Actions (`docker/setup-buildx-action`, `docker/build-push-action`) are pinned to commit SHAs that resolve to their claimed version tags
- Re-verified after the review-feedback changes: `docker build --no-cache` succeeds, container starts, `GET /` → `200`, and `id` inside the container confirms `uid=100(zero) gid=101(zero)`

`build-image` ran for real on this PR and passed, alongside the existing Format, Lint, Go Lint, and Go Test jobs:

| Check | Result | Time |
| --- | --- | --- |
| Build image | ✅ pass | 37s |
| Format | ✅ pass | 26s |
| Go Lint | ✅ pass | 26s |
| Go Test | ✅ pass | 33s |
| Lint | ✅ pass | 20s |
| GitGuardian Security Checks | ✅ pass | 1s |

