### PR TITLE
chore(`deps`): bump `hono` to fix dependabot alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  hono: '>=4.12.34'
-  '@hono/node-server': '>=1.19.15'
-
 importers:
 
   .:
@@ -293,7 +289,7 @@ packages:
     resolution: {integrity: sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.34'
+      hono: ^4
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  hono: '>=4.12.34'
+  '@hono/node-server': '>=1.19.15'
+
 importers:
 
   .:
@@ -285,11 +289,11 @@ packages:
   '@fontsource/inter@5.2.8':
     resolution: {integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+  '@hono/node-server@1.19.15':
+    resolution: {integrity: sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.34'
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1497,8 +1501,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.25:
-    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -2781,9 +2785,9 @@ snapshots:
 
   '@fontsource/inter@5.2.8': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.25)':
+  '@hono/node-server@1.19.15(hono@4.12.34)':
     dependencies:
-      hono: 4.12.25
+      hono: 4.12.34
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2811,7 +2815,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
+      '@hono/node-server': 1.19.15(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -2821,7 +2825,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1(supports-color@8.1.1)
       express-rate-limit: 8.5.2(express@5.2.1(supports-color@8.1.1))
-      hono: 4.12.25
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3907,7 +3911,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.25: {}
+  hono@4.12.34: {}
 
   http-errors@2.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,7 @@ allowBuilds:
   lefthook: false
 
 minimumReleaseAge: 10080
+
+overrides:
+  hono: '>=4.12.34'
+  '@hono/node-server': '>=1.19.15'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,3 @@ allowBuilds:
   lefthook: false
 
 minimumReleaseAge: 10080
-
-overrides:
-  hono: '>=4.12.34'
-  '@hono/node-server': '>=1.19.15'


### PR DESCRIPTION
Close: #102 

## 🚀 Summary

Bump `hono` (4.12.25 → 4.12.34) and `@hono/node-server` (1.19.14 → 1.19.15) to resolve Dependabot security advisory. Both are transitive dev-tool-only dependencies via `shadcn → @modelcontextprotocol/sdk → hono`, not imported in application source.

## ✏️ Changes

- Updated with `pnpm.overrides` in `pnpm-workspace.yaml` for scoped resolution of `hono` and `@hono/node-server` 
- Lockfile updated with new resolved versions
- After upgrading, removed override from `pnpm-workspace.yaml` and `pnpm-lock.yaml` with reference to [PR comment](https://github.com/String-dxd/teacher-workspace/pull/97#discussion_r3782963866)


## 🧪 Test Plan

**Range verification:**

| Parent | Declared range | Bumped version | Satisfies? |
|--------|---------------|----------------|------------|
| `@modelcontextprotocol/sdk` | `"hono": "^4.11.4"` | `4.12.34` | Yes |
| `@modelcontextprotocol/sdk` | `"@hono/node-server": "^1.19.9"` | `1.19.15` | Yes |

Verified via:

```sh
find node_modules/.pnpm -path "*@modelcontextprotocol+sdk*/package.json" -exec grep -A1 '"hono"' {} \;
find node_modules/.pnpm -path "*@modelcontextprotocol+sdk*/package.json" -exec grep -A1 '"@hono/node-server"' {} \;
```

- [x] pnpm audit — hono and @hono/node-server alerts resolved
- [x] pnpm lint — clean
- [x] pnpm build — succeeds