### PR TITLE
chore(`server/httputil`): add test for `RenderPlain` and `RenderJSON`

### DIFF
--- a/server/internal/httputil/httputil_test.go
+++ b/server/internal/httputil/httputil_test.go
@@ -1,0 +1,139 @@
+package httputil_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/String-sg/teacher-workspace/server/internal/httputil"
+	"github.com/String-sg/teacher-workspace/server/pkg/require"
+)
+
+func TestRenderPlain(t *testing.T) {
+	t.Run("sets Content-Type header", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		rec := httptest.NewRecorder()
+
+		httputil.RenderPlain(rec, logger, http.StatusInternalServerError)
+		res := rec.Result()
+
+		require.Equal(t, "text/plain; charset=UTF-8", res.Header.Get("Content-Type"))
+	})
+
+	t.Run("sets X-Content-Type-Options header", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		rec := httptest.NewRecorder()
+
+		httputil.RenderPlain(rec, logger, http.StatusInternalServerError)
+		res := rec.Result()
+
+		require.Equal(t, "nosniff", res.Header.Get("X-Content-Type-Options"))
+	})
+
+	t.Run("responds with status code from given status code", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		rec := httptest.NewRecorder()
+
+		httputil.RenderPlain(rec, logger, http.StatusInternalServerError)
+		res := rec.Result()
+
+		require.Equal(t, 500, res.StatusCode)
+	})
+
+	t.Run("responds with text from given status code", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		rec := httptest.NewRecorder()
+
+		httputil.RenderPlain(rec, logger, http.StatusInternalServerError)
+
+		require.Equal(t, "Internal Server Error", rec.Body.String())
+	})
+
+	t.Run("logs error message", func(t *testing.T) {
+		var logs bytes.Buffer
+		logger := slog.New(slog.NewJSONHandler(&logs, nil))
+		rec := httptest.NewRecorder()
+
+		httputil.RenderPlain(rec, logger, http.StatusNoContent)
+
+		type logLine struct {
+			Level    string `json:"level"`
+			Renderer string `json:"renderer"`
+			Err      string `json:"err"`
+		}
+		var got logLine
+		if err := json.Unmarshal(logs.Bytes(), &got); err != nil {
+			t.Fatalf("decoding log output: %v", err)
+		}
+
+		require.Equal(t, "ERROR", got.Level)
+		require.Equal(t, "plain", got.Renderer)
+		require.Equal(t, "http: request method or response status code does not allow body", got.Err)
+	})
+}
+
+func TestRenderJSON(t *testing.T) {
+	t.Run("sets Content-Type header", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		rec := httptest.NewRecorder()
+
+		httputil.RenderJSON(rec, logger, http.StatusInternalServerError, nil)
+		res := rec.Result()
+
+		require.Equal(t, "application/json; charset=UTF-8", res.Header.Get("Content-Type"))
+	})
+
+	t.Run("sets X-Content-Type-Options header", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		rec := httptest.NewRecorder()
+
+		httputil.RenderJSON(rec, logger, http.StatusInternalServerError, nil)
+		res := rec.Result()
+
+		require.Equal(t, "nosniff", res.Header.Get("X-Content-Type-Options"))
+	})
+
+	t.Run("responds with status code from given status code", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		rec := httptest.NewRecorder()
+
+		httputil.RenderJSON(rec, logger, http.StatusInternalServerError, nil)
+		res := rec.Result()
+
+		require.Equal(t, 500, res.StatusCode)
+	})
+
+	t.Run("responds with JSON from given value", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		rec := httptest.NewRecorder()
+
+		httputil.RenderJSON(rec, logger, http.StatusInternalServerError, httputil.ErrorResponse{Message: "Internal Server Error"})
+
+		require.Equal(t, `{"message":"Internal Server Error"}`+"\n", rec.Body.String())
+	})
+
+	t.Run("logs error message", func(t *testing.T) {
+		var logs bytes.Buffer
+		logger := slog.New(slog.NewJSONHandler(&logs, nil))
+		rec := httptest.NewRecorder()
+
+		httputil.RenderJSON(rec, logger, http.StatusInternalServerError, func() {})
+
+		type logLine struct {
+			Level    string `json:"level"`
+			Renderer string `json:"renderer"`
+			Err      string `json:"err"`
+		}
+		var got logLine
+		if err := json.Unmarshal(logs.Bytes(), &got); err != nil {
+			t.Fatalf("decoding log output: %v", err)
+		}
+
+		require.Equal(t, "ERROR", got.Level)
+		require.Equal(t, "json", got.Renderer)
+		require.Equal(t, "json: unsupported type: func()", got.Err)
+	})
+}

--- a/server/internal/httputil/httputil_test.go
+++ b/server/internal/httputil/httputil_test.go
@@ -36,7 +36,7 @@ func TestRenderPlain(t *testing.T) {
 		}
 	})
 
-	t.Run("responds with status code from given status code", func(t *testing.T) {
+	t.Run("responds with the expected status code", func(t *testing.T) {
 		logger := slog.New(slog.DiscardHandler)
 		rec := httptest.NewRecorder()
 
@@ -48,7 +48,7 @@ func TestRenderPlain(t *testing.T) {
 		}
 	})
 
-	t.Run("responds with text from given status code", func(t *testing.T) {
+	t.Run("responds with the expected body", func(t *testing.T) {
 		logger := slog.New(slog.DiscardHandler)
 		rec := httptest.NewRecorder()
 
@@ -113,7 +113,7 @@ func TestRenderJSON(t *testing.T) {
 		}
 	})
 
-	t.Run("responds with status code from given status code", func(t *testing.T) {
+	t.Run("responds with the expected status code", func(t *testing.T) {
 		logger := slog.New(slog.DiscardHandler)
 		rec := httptest.NewRecorder()
 
@@ -125,7 +125,7 @@ func TestRenderJSON(t *testing.T) {
 		}
 	})
 
-	t.Run("responds with JSON from given value", func(t *testing.T) {
+	t.Run("responds with the expected body", func(t *testing.T) {
 		logger := slog.New(slog.DiscardHandler)
 		rec := httptest.NewRecorder()
 

--- a/server/internal/httputil/httputil_test.go
+++ b/server/internal/httputil/httputil_test.go
@@ -59,7 +59,7 @@ func TestRenderPlain(t *testing.T) {
 		}
 	})
 
-	t.Run("logs error message", func(t *testing.T) {
+	t.Run("logs error message when it fails to write body", func(t *testing.T) {
 		var logs bytes.Buffer
 		logger := slog.New(slog.NewJSONHandler(&logs, nil))
 		rec := httptest.NewRecorder()
@@ -136,7 +136,7 @@ func TestRenderJSON(t *testing.T) {
 		}
 	})
 
-	t.Run("logs error message", func(t *testing.T) {
+	t.Run("logs error message when it fails to encode the body to JSON", func(t *testing.T) {
 		var logs bytes.Buffer
 		logger := slog.New(slog.NewJSONHandler(&logs, nil))
 		rec := httptest.NewRecorder()

--- a/server/internal/httputil/httputil_test.go
+++ b/server/internal/httputil/httputil_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/String-sg/teacher-workspace/server/internal/httputil"
-	"github.com/String-sg/teacher-workspace/server/pkg/require"
 )
 
 func TestRenderPlain(t *testing.T) {
@@ -20,7 +19,9 @@ func TestRenderPlain(t *testing.T) {
 		httputil.RenderPlain(rec, logger, http.StatusInternalServerError)
 		res := rec.Result()
 
-		require.Equal(t, "text/plain; charset=UTF-8", res.Header.Get("Content-Type"))
+		if want, got := "text/plain; charset=UTF-8", res.Header.Get("Content-Type"); want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
 	})
 
 	t.Run("sets X-Content-Type-Options header", func(t *testing.T) {
@@ -30,7 +31,9 @@ func TestRenderPlain(t *testing.T) {
 		httputil.RenderPlain(rec, logger, http.StatusInternalServerError)
 		res := rec.Result()
 
-		require.Equal(t, "nosniff", res.Header.Get("X-Content-Type-Options"))
+		if want, got := "nosniff", res.Header.Get("X-Content-Type-Options"); want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
 	})
 
 	t.Run("responds with status code from given status code", func(t *testing.T) {
@@ -40,7 +43,9 @@ func TestRenderPlain(t *testing.T) {
 		httputil.RenderPlain(rec, logger, http.StatusInternalServerError)
 		res := rec.Result()
 
-		require.Equal(t, 500, res.StatusCode)
+		if want, got := 500, res.StatusCode; want != got {
+			t.Errorf("want: %d; got: %d", want, got)
+		}
 	})
 
 	t.Run("responds with text from given status code", func(t *testing.T) {
@@ -49,7 +54,9 @@ func TestRenderPlain(t *testing.T) {
 
 		httputil.RenderPlain(rec, logger, http.StatusInternalServerError)
 
-		require.Equal(t, "Internal Server Error", rec.Body.String())
+		if want, got := "Internal Server Error", rec.Body.String(); want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
 	})
 
 	t.Run("logs error message", func(t *testing.T) {
@@ -59,19 +66,25 @@ func TestRenderPlain(t *testing.T) {
 
 		httputil.RenderPlain(rec, logger, http.StatusNoContent)
 
-		type logLine struct {
+		type logRecord struct {
 			Level    string `json:"level"`
 			Renderer string `json:"renderer"`
 			Err      string `json:"err"`
 		}
-		var got logLine
-		if err := json.Unmarshal(logs.Bytes(), &got); err != nil {
+		var lc logRecord
+		if err := json.Unmarshal(logs.Bytes(), &lc); err != nil {
 			t.Fatalf("decoding log output: %v", err)
 		}
 
-		require.Equal(t, "ERROR", got.Level)
-		require.Equal(t, "plain", got.Renderer)
-		require.Equal(t, "http: request method or response status code does not allow body", got.Err)
+		if want, got := "ERROR", lc.Level; want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
+		if want, got := "plain", lc.Renderer; want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
+		if want, got := "http: request method or response status code does not allow body", lc.Err; want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
 	})
 }
 
@@ -83,7 +96,9 @@ func TestRenderJSON(t *testing.T) {
 		httputil.RenderJSON(rec, logger, http.StatusInternalServerError, nil)
 		res := rec.Result()
 
-		require.Equal(t, "application/json; charset=UTF-8", res.Header.Get("Content-Type"))
+		if want, got := "application/json; charset=UTF-8", res.Header.Get("Content-Type"); want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
 	})
 
 	t.Run("sets X-Content-Type-Options header", func(t *testing.T) {
@@ -93,7 +108,9 @@ func TestRenderJSON(t *testing.T) {
 		httputil.RenderJSON(rec, logger, http.StatusInternalServerError, nil)
 		res := rec.Result()
 
-		require.Equal(t, "nosniff", res.Header.Get("X-Content-Type-Options"))
+		if want, got := "nosniff", res.Header.Get("X-Content-Type-Options"); want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
 	})
 
 	t.Run("responds with status code from given status code", func(t *testing.T) {
@@ -103,7 +120,9 @@ func TestRenderJSON(t *testing.T) {
 		httputil.RenderJSON(rec, logger, http.StatusInternalServerError, nil)
 		res := rec.Result()
 
-		require.Equal(t, 500, res.StatusCode)
+		if want, got := 500, res.StatusCode; want != got {
+			t.Errorf("want: %d; got: %d", want, got)
+		}
 	})
 
 	t.Run("responds with JSON from given value", func(t *testing.T) {
@@ -112,7 +131,9 @@ func TestRenderJSON(t *testing.T) {
 
 		httputil.RenderJSON(rec, logger, http.StatusInternalServerError, httputil.ErrorResponse{Message: "Internal Server Error"})
 
-		require.Equal(t, `{"message":"Internal Server Error"}`+"\n", rec.Body.String())
+		if want, got := `{"message":"Internal Server Error"}`+"\n", rec.Body.String(); want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
 	})
 
 	t.Run("logs error message", func(t *testing.T) {
@@ -127,13 +148,19 @@ func TestRenderJSON(t *testing.T) {
 			Renderer string `json:"renderer"`
 			Err      string `json:"err"`
 		}
-		var got logLine
-		if err := json.Unmarshal(logs.Bytes(), &got); err != nil {
+		var line logLine
+		if err := json.Unmarshal(logs.Bytes(), &line); err != nil {
 			t.Fatalf("decoding log output: %v", err)
 		}
 
-		require.Equal(t, "ERROR", got.Level)
-		require.Equal(t, "json", got.Renderer)
-		require.Equal(t, "json: unsupported type: func()", got.Err)
+		if want, got := "ERROR", line.Level; want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
+		if want, got := "json", line.Renderer; want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
+		if want, got := "json: unsupported type: func()", line.Err; want != got {
+			t.Errorf("want: %q; got: %q", want, got)
+		}
 	})
 }


### PR DESCRIPTION
Closes #99 

## 🚀 Summary

Added missing tests from `httputil` renderers functions.

## ✏️ Changes

- **`internal/httputil`**: adds `httputil_test.go` as an external test package (`httputil_test`), with ten subtests across `TestRenderPlain` and `TestRenderJSON`. Each function is covered for the `Content-Type` header, the `X-Content-Type-Options` header, the status code, the response body, and the write-failure log line.

## 🧪 Test Plan

- `go test ./server/internal/httputil/` passes
- `go vet ./server/internal/httputil/` clean
- `gofmt -l server/` no output
