### PR TITLE
chore(apps/host/deps): bump js-yaml to 4.3.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1653,8 +1653,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3573,7 +3573,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -4019,7 +4019,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
Closes #103

## Summary

- Bumps the transitive `js-yaml` dependency (`host -> shadcn -> cosmiconfig@9.0.2 -> js-yaml`) from `4.2.0` to `4.3.1`, fixing Dependabot advisories [YAML merge-key chains can force quadratic CPU consumption](https://github.com/String-dxd/teacher-workspace/security/dependabot/12) and [Quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870 fix not backported)](https://github.com/String-dxd/teacher-workspace/security/dependabot/37).
- `cosmiconfig@9.0.2` already declares `js-yaml: ^4.1.0`, which already permits `4.3.1`. This is a lockfile-only re-resolution; no `pnpm.overrides` entry was needed (confirmed by removing a trial override and reinstalling: `js-yaml` still resolves to `4.3.1` on its own).

## Test plan

```zsh
pnpm install
pnpm why js-yaml    # confirms 4.3.1
pnpm audit          # no js-yaml advisories
pnpm build          # succeeds
```